### PR TITLE
Work around for servers that send unquoted algorithm information

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -205,7 +205,12 @@ func digestParts(req *http.Request, resp *http.Response) (res map[string]string)
 			r = strings.TrimSpace(r)
 			for _, w := range wantedHeaders {
 				if strings.Contains(r, w) {
-					res[w] = strings.Split(r, `"`)[1]
+					// Some servers send the algorithm without quotes - then split at "=".
+					if strings.Contains(r, `"`) {
+						res[w] = strings.Split(r, `"`)[1]
+					} else {
+						res[w] = strings.Split(r, "=")[1]
+					}
 					if w == "qop" {
 						if strings.Contains(res[w], "auth-int") && req.Body != nil {
 							res[w] = "auth-int"


### PR DESCRIPTION
Please consider to merge this pull request as a workaround for misbehaving(?) servers that don't quote the algorithm header information.

thx & cheers,
Andreas